### PR TITLE
Fix for build error in ArbitraryResource

### DIFF
--- a/src/main/java/org/qortal/api/resource/ArbitraryResource.java
+++ b/src/main/java/org/qortal/api/resource/ArbitraryResource.java
@@ -1177,7 +1177,7 @@ public class ArbitraryResource {
 		Security.checkApiCallAllowed(request);
 
 		try (final Repository repository = RepositoryManager.getRepository()) {
-			ArbitraryDataCacheManager.getInstance().buildArbitraryResourcesCache(repository, true);
+			ArbitraryDataCacheManager.getInstance().buildCache(repository, true);
 
 			return "true";
 		} catch (DataException e) {


### PR DESCRIPTION
[ERROR] qortal/src/main/java/org/qortal/api/resource/ArbitraryResource.java:[1180,64] cannot find symbol
  symbol:   method buildArbitraryResourcesCache(org.qortal.repository.Repository,boolean)
  location: class org.qortal.controller.arbitrary.ArbitraryDataCacheManager